### PR TITLE
Refactor real-time clock behaviour

### DIFF
--- a/lib/nerves_time.ex
+++ b/lib/nerves_time.ex
@@ -29,6 +29,9 @@ defmodule NervesTime do
   `NervesTime` decides that NTP is synchronized when `ntpd` sends a
   notification that the device's clock stratum is 4 or less. Clock adjustments
   occur before this, though.
+
+  Once NTP is synchronized, it will remain that way until the `nerves_time`
+  application is restarted.
   """
   @spec synchronized?() :: boolean()
   defdelegate synchronized?, to: NervesTime.Ntpd

--- a/lib/nerves_time/file_time.ex
+++ b/lib/nerves_time/file_time.ex
@@ -15,9 +15,9 @@ defmodule NervesTime.FileTime do
   Update the file holding a stamp of the current time.
   """
   @impl NervesTime.RealTimeClock
-  @spec update(state) :: :ok | {:error, File.posix()}
-  def update(_state) do
-    File.touch(time_file())
+  def set_time(state, _naive_date_time) do
+    _ = File.touch(time_file())
+    state
   end
 
   @doc """
@@ -25,11 +25,12 @@ defmodule NervesTime.FileTime do
   the Unix epoch time (1970-01-01) should that not work.
   """
   @impl NervesTime.RealTimeClock
-  @spec time(state) :: {:ok, NaiveDateTime.t()} | {:error, any()}
-  def time(_state) do
+  def get_time(state) do
     with {:ok, stat} <- File.stat(time_file()),
          {:ok, %NaiveDateTime{} = mtime} <- NaiveDateTime.from_erl(stat.mtime) do
       {:ok, mtime}
+    else
+      _ -> {:unavailable, state}
     end
   end
 

--- a/lib/nerves_time/real_time_clock.ex
+++ b/lib/nerves_time/real_time_clock.ex
@@ -1,26 +1,40 @@
 defmodule NervesTime.RealTimeClock do
   @moduledoc """
-  Behaviour for hardware based real time clocks.
+  Behaviour for real-time clocks implementations.
   """
 
   @typedoc "Internal state of the hardware clock"
   @type state :: any()
 
   @doc """
-  Initialize the hardware clock.
-  Called once before `ntpd` starts.
+  Initialize the clock
+
+  This is called when `nerves_time` starts. If it fails, `nerves_time`
+  won't call any of the other functions.
   """
-  @callback init(args :: any()) :: {:ok, state} | {:error, reason :: any()}
+  @callback init(args :: any()) :: {:ok, state()} | {:error, reason :: any()}
 
   @doc """
-  Retrieve the time from the hardware clock.
-  Called once when `ntpd` before starts.
+  Get the time from the clock
+
+  This is called after `init/1` returns successfully to see if the
+  system clock should be updated.
+
+  If the time isn't available, the implementation should return `unavailable`.
+  `set_time/2` will be called when the time is known.
   """
-  @callback time(state) :: {:ok, NaiveDateTime.t()} | {:error, reason :: any()}
+  @callback get_time(state()) ::
+              {:ok, NaiveDateTime.t(), state()} | {:unavailable, state()}
 
   @doc """
-  Set a time to the hardware clock.
-  Called every time a stratum comes in from `ntpd`
+  Set the clock
+
+  This is called if `nerves_time` determines that the implementation is out
+  of sync with the true time and at regular intervals (usually 11 minutes) as
+  updates come in from NTP.
+
+  If the time can't be set, the implementation can either wait to be called
+  the next time or take some other action.
   """
-  @callback update(state) :: :ok | {:error, reason :: any()}
+  @callback set_time(state(), NaiveDateTime.t()) :: state()
 end


### PR DESCRIPTION
@ConnorRigby - I was thinking about the RTC behaviour and figured that now was a good time to get in any API changes. I've only made changes to the behaviour and wanted to get feedback before fixing the rest of the code and propagating them to the RTC implementations.

Here's the summary:

1. Update naming - I renamed the functions to `get_time` and `set_time`. That felt pretty explicit on what they were supposed to do.
2. Return state. This lets implementations modify their state without starting up a `GenServer` to hold it.
3. Make the API explicit in ignoring errors. I can't think of anything `nerves_time` could do with errors from getting or setting the time other than to retry - like it does already. The updates basically say that now.

Let me know what you think.