### PR TITLE
Rename :unavailable to :unset to reflect implementation

### DIFF
--- a/lib/nerves_time/file_time.ex
+++ b/lib/nerves_time/file_time.ex
@@ -30,7 +30,7 @@ defmodule NervesTime.FileTime do
          {:ok, %NaiveDateTime{} = mtime} <- NaiveDateTime.from_erl(stat.mtime) do
       {:ok, mtime, state}
     else
-      _ -> {:unavailable, state}
+      _ -> {:unset, state}
     end
   end
 

--- a/lib/nerves_time/file_time.ex
+++ b/lib/nerves_time/file_time.ex
@@ -28,7 +28,7 @@ defmodule NervesTime.FileTime do
   def get_time(state) do
     with {:ok, stat} <- File.stat(time_file()),
          {:ok, %NaiveDateTime{} = mtime} <- NaiveDateTime.from_erl(stat.mtime) do
-      {:ok, mtime}
+      {:ok, mtime, state}
     else
       _ -> {:unavailable, state}
     end

--- a/lib/nerves_time/ntpd.ex
+++ b/lib/nerves_time/ntpd.ex
@@ -322,7 +322,7 @@ defmodule NervesTime.Ntpd do
           adjust_system_time_to_rtc(rtc, rtc_time, next_rtc_state)
 
         # Try to fix an unset or corrupt RTC
-        {:unavailable, next_rtc_state} ->
+        {:unset, next_rtc_state} ->
           system_time = NaiveDateTime.utc_now()
           rtc.set_time(next_rtc_state, system_time)
       end

--- a/lib/nerves_time/real_time_clock.ex
+++ b/lib/nerves_time/real_time_clock.ex
@@ -20,11 +20,11 @@ defmodule NervesTime.RealTimeClock do
   This is called after `init/1` returns successfully to see if the
   system clock should be updated.
 
-  If the time isn't available, the implementation should return `unavailable`.
+  If the time isn't set, the implementation should return `:unset`.
   `set_time/2` will be called when the time is known.
   """
   @callback get_time(state()) ::
-              {:ok, NaiveDateTime.t(), state()} | {:unavailable, state()}
+              {:ok, NaiveDateTime.t(), state()} | {:unset, state()}
 
   @doc """
   Set the clock


### PR DESCRIPTION
When `nerves_time` has a need to retry RTCs to get the time,
`:unavailable` will be useful. Now, the only thing that `nerves_time` can
handle is unset or something semantically equivalent. I.e., if this is
returned, then a call will be made to set the clock.