### PR TITLE
Don't declare synchronized until stratum <= 4

### DIFF
--- a/lib/nerves_time/ntpd.ex
+++ b/lib/nerves_time/ntpd.ex
@@ -363,11 +363,11 @@ defmodule NervesTime.Ntpd do
         # If the RTC is off by more than an hour, then update it.
         # Otherwise, wait for NTP to give it a better time
         rtc_delta =
-          NaiveDateTime.diff(rtc_time, system_time, :second)
+          NaiveDateTime.diff(rtc_time, new_time, :second)
           |> div(3600)
 
         if rtc_delta != 0,
-          do: rtc.set_time(rtc_state, system_time),
+          do: rtc.set_time(rtc_state, new_time),
           else: rtc_state
     end
   end

--- a/test/fixtures/fake_busybox_ntpd_stratum16
+++ b/test/fixtures/fake_busybox_ntpd_stratum16
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# This script simulates what Busybox ntpd prints out on successful runs
+
+while getopts 'ndp:S:' c
+do
+  case $c in
+    S) NTPD_SCRIPT="$OPTARG" ;;
+    *) ;;
+  esac
+done
+
+if [ -z "$NTPD_SCRIPT" ]; then
+  echo "-S not specified!!!" 1>&2
+  exit 1
+fi
+
+# Print the startup messages
+cat <<EOF
+ntpd: '0.pool.ntp.org' is 129.70.132.37
+ntpd: '1.pool.ntp.org' is 193.225.190.6
+ntpd: sending query to 193.225.190.6
+ntpd: sending query to 129.70.132.37
+EOF
+
+while true; do
+    cat <<EOF
+ntpd: reply from 129.70.132.37: offset:-0.007726 delay:0.105911 status:0x24 strat:16 refid:0x46824681 rootdelay:0.000412 reach:0x01
+ntpd: reply from 193.225.190.6: offset:-0.010856 delay:0.119149 status:0x24 strat:16 refid:0x11626fc3 rootdelay:0.004623 reach:0x01
+ntpd: sending query to 193.225.190.6
+ntpd: sending query to 129.70.132.37
+EOF
+    freq_drift_ppm=0 offset=0.190975 stratum=16 poll_interval=1 "$NTPD_SCRIPT" stratum
+    sleep 1
+done
+

--- a/test/nerves_time_test.exs
+++ b/test/nerves_time_test.exs
@@ -39,6 +39,15 @@ defmodule NervesTimeTest do
     refute NervesTime.synchronized?()
   end
 
+  test "reports that time not synchronized when stratum 16" do
+    Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd_stratum16"))
+    Application.start(:nerves_time)
+    Process.sleep(100)
+
+    refute NervesTime.synchronized?()
+    assert NervesTime.Ntpd.clean_start?()
+  end
+
   test "delays ntpd restart after a GenServer crash" do
     # This one should be clean
     Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd"))


### PR DESCRIPTION
This fixes an issue where `nerves_time` would report synchronized on the
first ntpd reports. These are stratum "16" and the time is very much not
in sync.