### PR TITLE
Add terminate callback on RTC for final ops

### DIFF
--- a/lib/nerves_time/file_time.ex
+++ b/lib/nerves_time/file_time.ex
@@ -23,6 +23,15 @@ defmodule NervesTime.FileTime do
   def init(_args), do: {:ok, time_file()}
 
   @doc """
+  Update the timestamp one final time
+  """
+  @impl NervesTime.RealTimeClock
+  def terminate(path) do
+    _ = File.touch(path)
+    :ok
+  end
+
+  @doc """
   Update the file holding a stamp of the current time.
   """
   @impl NervesTime.RealTimeClock

--- a/lib/nerves_time/real_time_clock.ex
+++ b/lib/nerves_time/real_time_clock.ex
@@ -15,6 +15,15 @@ defmodule NervesTime.RealTimeClock do
   @callback init(args :: any()) :: {:ok, state()} | {:error, reason :: any()}
 
   @doc """
+  Clean up the clock state
+
+  This is called when `nerves_time` terminates. It's not guaranteed to be
+  called, but if it is, it should clean up or do any final operations on
+  the RTC.
+  """
+  @callback terminate(state()) :: :ok
+
+  @doc """
   Get the time from the clock
 
   This is called after `init/1` returns successfully to see if the


### PR DESCRIPTION
This is desirable for the FileTime implementation so that it can touch the
file one final time before the restart/reboot/whatever. This reduces the
lost time especially in situations where NTP isn't working so well.

This undoes the functionality that that commit
5da6fbd72dd1465500ce312bbd446a8a671061bd removed, but in a way that RTC
modules can ignore if they want. (Which is probably what they want since
they already know the time and it's best to avoid I2C or other transactions
on a terminate)