### PR TITLE
Fix crash when setting the time

### DIFF
--- a/lib/nerves_time/ntpd.ex
+++ b/lib/nerves_time/ntpd.ex
@@ -182,10 +182,10 @@ defmodule NervesTime.Ntpd do
     handle_ntpd_report(report, state)
   end
 
-  def handle_info({:EXIT, daemon, :normal}, %{daemon: daemon} = state) do
-    # Normal exits for the ntpd daemon pid are initiated by us, so
-    # let them run their course.
-    {:noreply, %{state | daemon: nil}}
+  def handle_info({:EXIT, _pid, :normal}, state) do
+    # Normal exits come from the ntpd daemon and calls to set the time.
+    # They're initiated by us, so they can be safely ignored.
+    {:noreply, state}
   end
 
   def handle_info({:EXIT, from, reason}, state) do
@@ -243,7 +243,7 @@ defmodule NervesTime.Ntpd do
 
   defp stop_ntpd(%State{daemon: pid} = state) do
     GenServer.stop(pid)
-    %State{state | synchronized?: false}
+    %State{state | daemon: nil, synchronized?: false}
   end
 
   defp handle_ntpd_report({"stratum", _freq_drift_ppm, _offset, stratum, _poll_interval}, state) do


### PR DESCRIPTION
This fixes a "crash" that would happen after setting the system time.
Thanks to process supervision, this would delay ntpd from starting.
Here is the log message that changes with the fix:

```
00:01:30.052 [info]  RTC (NervesTime.FileTime) reports that the time is ~N[2020-02-19 00:01:30]

00:01:30.087 [warn]  ntpd crash detected. Delaying next start...
```

With the fix, the log looks something like this:

```
00:00:17.469 [info]  RTC (NervesTime.FileTime) reports that the time is ~N[2020-02-19 01:13:49]

01:13:49.002 [info]  nerves_time set system clock to 2020-02-19 01:13:49 UTC

01:13:49.028 [debug] Starting /usr/sbin/ntpd with: ["-n", "-S", "/srv/erlang/lib/nerves_time-0.4.0/priv/ntpd_script", "-p", "0.pool.ntp.org", "-p", "1.pool.ntp.org", "-p", "2.pool.ntp.org", "-p", "3.pool.ntp.org"]
```