### PR TITLE
Update CI to OTP 24 and Elixir 1.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
       - run: mix deps.get
       - run: mix format --check-formatted
       - run: mix deps.unlock --check-unused
-      - run: mix compile --warnings-as-errors
       - run: mix docs
       - run: mix hex.build
       - run: mix test
@@ -64,7 +63,6 @@ jobs:
       - <<: *install_hex_rebar
       - <<: *install_system_deps
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
   build_elixir_1_9_otp_22:
@@ -76,7 +74,6 @@ jobs:
       - <<: *install_hex_rebar
       - <<: *install_system_deps
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
   build_elixir_1_8_otp_22:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ install_system_deps: &install_system_deps
         apk add build-base
 
 jobs:
-  build_elixir_1_11_otp_23:
+  build_elixir_1_12_otp_24:
     docker:
-      - image: hexpm/elixir:1.11.3-erlang-23.2.7-alpine-3.13.2
+      - image: hexpm/elixir:1.12.1-erlang-24.0.2-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
@@ -44,9 +44,20 @@ jobs:
             - _build
             - deps
 
+  build_elixir_1_11_otp_23:
+    docker:
+      - image: hexpm/elixir:1.11.4-erlang-23.3.4-alpine-3.13.3
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
+      - run: mix test
+
   build_elixir_1_10_otp_23:
     docker:
-      - image: hexpm/elixir:1.10.4-erlang-23.1.2-alpine-3.12.1
+      - image: hexpm/elixir:1.10.4-erlang-23.3.4-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
@@ -58,7 +69,7 @@ jobs:
 
   build_elixir_1_9_otp_22:
     docker:
-      - image: hexpm/elixir:1.9.4-erlang-22.3.4.9-alpine-3.12.0
+      - image: hexpm/elixir:1.9.4-erlang-22.3.4.18-alpine-3.13.3
     <<: *defaults
     steps:
       - checkout
@@ -77,13 +88,13 @@ jobs:
       - <<: *install_hex_rebar
       - <<: *install_system_deps
       - run: mix deps.get
-      - run: mix compile
       - run: mix test
 
 workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23
       - build_elixir_1_10_otp_23
       - build_elixir_1_9_otp_22

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,4 +2,9 @@
 socket_path = Path.join(System.tmp_dir!(), "nerves_time_comm")
 File.rm(socket_path)
 
+# Always warning as errors
+if Version.match?(System.version(), "~> 1.10") do
+  Code.put_compiler_option(:warnings_as_errors, true)
+end
+
 ExUnit.start()


### PR DESCRIPTION
- CI: Add OTP-24 and Elixir 1.12
- Always turn warnings to errors
