### PR TITLE
Battery Backed RTC Implementation

### DIFF
--- a/lib/nerves_time.ex
+++ b/lib/nerves_time.ex
@@ -43,7 +43,10 @@ defmodule NervesTime do
   application is restarted.
   """
   @spec synchronized?() :: boolean()
-  defdelegate synchronized?, to: NervesTime.Ntpd
+  def synchronized?() do
+    NervesTime.Ntpd.synchronized?() ||
+      NervesTime.SystemTime.synchronized?()
+  end
 
   @doc """
   Set the list of NTP servers

--- a/lib/nerves_time/battery_backed_time.ex
+++ b/lib/nerves_time/battery_backed_time.ex
@@ -1,0 +1,41 @@
+defmodule NervesTime.BatteryBackedTime do
+  @behaviour NervesTime.RealTimeClock
+
+  @moduledoc """
+  An implementation that always returns the system time.
+
+  This should be used only if you know the device has a battery backed realtime clock.
+  When `NervesTime.SystemTime` does a sanity check, the system time will be the same
+  as the rtc time. This can cause the system to report a sucessful synchronization, before
+  ntp synchronization has occured.
+  """
+
+  @doc false
+  @impl NervesTime.RealTimeClock
+  @spec init(args :: any()) :: {:ok, any()}
+  def init(_args) do
+    {:ok, :battery_backed_time}
+  end
+
+
+  @impl NervesTime.RealTimeClock
+  def terminate(_) do
+    :ok
+  end
+
+  @doc """
+  The system time is trusted, so this implemenation no ops.
+  """
+  @impl NervesTime.RealTimeClock
+  def set_time(_, _naive_date_time) do
+    :battery_backed_time
+  end
+
+  @doc """
+  Always return the system time because the rtc is battery backed.
+  """
+  @impl NervesTime.RealTimeClock
+  def get_time(_rtc) do
+    {:ok, NaiveDateTime.utc_now(), :battery_backed_time}
+  end
+end


### PR DESCRIPTION
Waiting for `NervesTime.Ntpd` to synchronize can cause unnecessary delay with a battery backed clock. If it is known that the device has a battery backed rtc allow that to be configured. This PR also adds a synchronized check to the system time. When using `BatterBackedTime` the rtc will be in sync on start, permitting `NervesTime.synchronized?/0` to evaluate true even if NTP has not been synchronized. 

```elixir
config :nerves_time, rtc: NervesTime.BatteryBackedTime
```
