### PR TITLE
don't prep ntp if no servers are configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ time will lag. The following line should be in the beginning or middle of the
 
 If you're using one of the official Nerves Systems, then this is all that's
 needed. `nerves_time` requires Busybox's `ntpd` and `date` applets to be
-enabled. If you haven't explicitly disabled the, they're probably enabled.
+enabled. If you haven't explicitly disabled them, they're probably enabled.
 
 ## Configuration
 
@@ -41,8 +41,8 @@ enabled. If you haven't explicitly disabled the, they're probably enabled.
 
 `nerves_time` by default does not block waiting for a valid system time to be set.
 This can result in your application running before the time has been adjusted, which
-may be undesirable. To lessen the likelyhood of that happening you can adjust 
-the `:await_initialization_timeout` config to wait for a valid system time to be set. 
+may be undesirable. To lessen the likelyhood of that happening you can adjust
+the `:await_initialization_timeout` config to wait for a valid system time to be set.
 If `nerves_time` fails to do that within the given timeframe it will stop blocking
 startup and continue trying asynchronously.
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -6,7 +6,7 @@ import Config
 # if you want to provide default values for your application for
 # 3rd-party users, it should be done in your "mix.exs" file.
 
-config :nerves_time, ntpd: "test/fixtures/fake_busybox_ntpd"
+config :nerves_time, ntpd: Path.join(File.cwd!(), "test/fixtures/fake_busybox_ntpd")
 
 # You can configure your application as:
 #

--- a/lib/nerves_time/ntpd.ex
+++ b/lib/nerves_time/ntpd.ex
@@ -116,7 +116,7 @@ defmodule NervesTime.Ntpd do
 
   @impl GenServer
   def handle_call({:set_ntp_servers, servers}, _from, state) do
-    new_state = %{state | servers: servers} |> stop_ntpd() |> schedule_ntpd_start()
+    new_state = %{state | servers: servers} |> cleanup_and_restart()
 
     {:reply, :ok, new_state}
   end
@@ -128,12 +128,7 @@ defmodule NervesTime.Ntpd do
 
   @impl GenServer
   def handle_call(:restart_ntpd, _from, state) do
-    new_state =
-      %{state | clean_start?: true}
-      |> stop_ntpd()
-      |> schedule_ntpd_start()
-
-    {:reply, :ok, new_state}
+    {:reply, :ok, cleanup_and_restart(state)}
   end
 
   @impl GenServer
@@ -165,6 +160,11 @@ defmodule NervesTime.Ntpd do
     # Log abnormal exits to aide debugging.
     Logger.info("NervesTime.Ntpd: unexpected :EXIT #{inspect(from)}/#{inspect(reason)}")
     {:stop, reason, state}
+  end
+
+  defp prep_ntpd_start(%State{servers: []} = state) do
+    # Don't prep ntpd if no servers are configured.
+    state
   end
 
   defp prep_ntpd_start(state) do
@@ -199,14 +199,33 @@ defmodule NervesTime.Ntpd do
     state
   end
 
+  defp cleanup_and_restart(state) do
+    state
+    |> stop_ntpd()
+    |> prep_ntpd_start()
+    |> schedule_ntpd_start()
+  end
+
   defp ntpd_restart_delay(%State{clean_start?: false}), do: @ntpd_restart_delay
   defp ntpd_restart_delay(%State{clean_start?: true}), do: @ntpd_clean_start_delay
 
-  defp stop_ntpd(%State{daemon: nil} = state), do: state
+  defp stop_ntpd(%State{daemon: pid, socket: socket} = state) do
+    unless is_nil(pid) do
+      GenServer.stop(pid)
+    end
 
-  defp stop_ntpd(%State{daemon: pid} = state) do
-    GenServer.stop(pid)
-    %State{state | daemon: nil, synchronized?: false}
+    unless is_nil(socket) do
+      :ok = :gen_udp.close(socket)
+    end
+
+    # this is needed otherwise dialyzer complains
+    try do
+      File.rm!(socket_path())
+    rescue
+      _ -> nil
+    end
+
+    %State{state | daemon: nil, socket: nil, synchronized?: false}
   end
 
   defp handle_ntpd_report({"stratum", _freq_drift_ppm, _offset, stratum, _poll_interval}, state) do

--- a/lib/nerves_time/ntpd.ex
+++ b/lib/nerves_time/ntpd.ex
@@ -189,7 +189,7 @@ defmodule NervesTime.Ntpd do
 
   defp schedule_ntpd_start(%State{servers: []} = state) do
     # Don't schedule ntpd to start if no servers configured.
-    Logger.warning("Not scheduling ntpd to start since no servers configured")
+    Logger.info("[NervesTime] Not scheduling ntpd to start (no servers configured)")
     state
   end
 

--- a/lib/nerves_time/system_time.ex
+++ b/lib/nerves_time/system_time.ex
@@ -147,12 +147,12 @@ defmodule NervesTime.SystemTime do
     final_rtc_state =
       case rtc.get_time(state.rtc_state) do
         {:ok, %NaiveDateTime{} = rtc_time, next_rtc_state} ->
-          Logger.info("RTC (#{inspect(rtc)}) reports that the time is #{inspect(rtc_time)}")
+          Logger.info("[#{inspect(rtc)}] RTC reports that the time is #{inspect(rtc_time)}")
           check_rtc_time_and_set(rtc, rtc_time, next_rtc_state)
 
         # Try to fix an unset or corrupt RTC
         {:unset, next_rtc_state} ->
-          Logger.info("RTC (#{inspect(rtc)}) reports that the time hasn't been set.")
+          Logger.info("[#{inspect(rtc)}] RTC reports that the time hasn't been set.")
           now = sane_system_time()
           rtc.set_time(next_rtc_state, now)
       end


### PR DESCRIPTION
when switching off NTP you see these messages:

```
11:19:01.455 [warning] ntpd crash detected. Delaying next start...

11:19:01.464 [warning] Not scheduling ntpd to start since no servers configured
```

this PR removes the first warning by skipping the prep function if no servers are configured

Additionally, I noticed that the udp socket wasn't being closed and cleaned up during `stop_ntpd`, and that the path to the ntpd used in tests (in `config.exs`) needed a full path for the tests to work correctly and stop a bunch of errors in the logs.