### PR TITLE
Add NTP event subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,53 @@ Here's the basic idea behind `nerves_time`:
   downs. This is currently only done at around 11 minute intervals.
 
 To check the NTP synchronization status, call `NervesTime.synchronized?/0`.
+To get the current sync snapshot, call `NervesTime.sync_status/0`.
+
+## Subscriptions
+
+Processes can subscribe to NTP daemon updates:
+
+```elixir
+NervesTime.subscribe()
+```
+
+Subscribers receive messages in the form:
+
+```elixir
+{:nerves_time, event, payload}
+```
+
+Live events:
+
+* `:sync_acquired`
+* `:sync_updated`
+* `:sync_lost`
+* `:clock_step`
+
+When subscribing, `nerves_time` immediately sends a sync status snapshot:
+
+```elixir
+{:nerves_time, :sync_status,
+ %{
+   synchronized?: boolean(),
+   last_sync_report: %{
+     freq_drift_ppm: integer(),
+     offset: float(),
+     stratum: integer(),
+     poll_interval: integer()
+   } | nil,
+   sync_acquired_at: DateTime.t() | nil,
+   last_sync_at: DateTime.t() | nil
+ }}
+```
+
+The snapshot is scoped to the current `nerves_time` runtime. After an
+application restart or device reboot, sync history is reset until `ntpd`
+reports synchronization again.
+
+`sync_acquired_at` is when synchronization was first confirmed in the current
+runtime. `last_sync_at` is the most recent successful sync update in the
+current runtime.
 
 ## Real Time Clock
 

--- a/lib/nerves_time.ex
+++ b/lib/nerves_time.ex
@@ -33,6 +33,21 @@ defmodule NervesTime do
     Defaults to `0`.
   """
 
+  @typedoc """
+  NTP daemon event names emitted to subscribers.
+  """
+  @type ntpd_event() :: :sync_aquired | :sync_updated | :sync_lost | :clock_step
+
+  @typedoc """
+  Metadata reported by the NTP helper script for a synchronization event.
+  """
+  @type ntpd_event_report() :: %{
+          freq_drift_ppm: integer(),
+          offset: float(),
+          stratum: integer(),
+          poll_interval: integer()
+        }
+
   @doc """
   Set the system time
   """
@@ -98,4 +113,27 @@ defmodule NervesTime do
   """
   @spec restart_ntpd() :: :ok | {:error, term()}
   defdelegate restart_ntpd(), to: NervesTime.Ntpd
+
+  @doc """
+  Subscribe a process to NTP daemon events.
+
+  Subscribers receive messages in the form:
+
+      {:nerves_time, event, report}
+
+  Where `event` is one of:
+
+    * `:sync_aquired`
+    * `:sync_updated`
+    * `:sync_lost`
+    * `:clock_step`
+  """
+  @spec subscribe(pid()) :: :ok
+  defdelegate subscribe(pid \\ self()), to: NervesTime.Ntpd
+
+  @doc """
+  Unsubscribe a process from NTP daemon events.
+  """
+  @spec unsubscribe(pid()) :: :ok
+  defdelegate unsubscribe(pid \\ self()), to: NervesTime.Ntpd
 end

--- a/lib/nerves_time.ex
+++ b/lib/nerves_time.ex
@@ -36,7 +36,7 @@ defmodule NervesTime do
   @typedoc """
   NTP daemon event names emitted to subscribers.
   """
-  @type ntpd_event() :: :sync_aquired | :sync_updated | :sync_lost | :clock_step
+  @type ntpd_event() :: :sync_status | :sync_acquired | :sync_updated | :sync_lost | :clock_step
 
   @typedoc """
   Metadata reported by the NTP helper script for a synchronization event.
@@ -46,6 +46,16 @@ defmodule NervesTime do
           offset: float(),
           stratum: integer(),
           poll_interval: integer()
+        }
+
+  @typedoc """
+  Current NTP synchronization state.
+  """
+  @type sync_status() :: %{
+          synchronized?: boolean(),
+          last_sync_report: ntpd_event_report() | nil,
+          sync_acquired_at: DateTime.t() | nil,
+          last_sync_at: DateTime.t() | nil
         }
 
   @doc """
@@ -67,6 +77,12 @@ defmodule NervesTime do
   """
   @spec synchronized?() :: boolean()
   defdelegate synchronized?, to: NervesTime.Ntpd
+
+  @doc """
+  Return the current NTP synchronization status.
+  """
+  @spec sync_status() :: sync_status()
+  defdelegate sync_status(), to: NervesTime.Ntpd
 
   @doc """
   Set the list of NTP servers
@@ -123,10 +139,14 @@ defmodule NervesTime do
 
   Where `event` is one of:
 
-    * `:sync_aquired`
+    * `:sync_status`
+    * `:sync_acquired`
     * `:sync_updated`
     * `:sync_lost`
     * `:clock_step`
+
+  `:sync_status` is sent immediately when subscribing so new subscribers can
+  observe the current synchronization state without replaying old events.
   """
   @spec subscribe(pid()) :: :ok
   defdelegate subscribe(pid \\ self()), to: NervesTime.Ntpd

--- a/lib/nerves_time/ntpd.ex
+++ b/lib/nerves_time/ntpd.ex
@@ -37,6 +37,9 @@ defmodule NervesTime.Ntpd do
             daemon: nil | pid(),
             synchronized?: boolean(),
             clean_start?: boolean(),
+            last_sync_report: map() | nil,
+            sync_acquired_at: DateTime.t() | nil,
+            last_sync_at: DateTime.t() | nil,
             subscribers: %{optional(pid()) => reference()}
           }
     defstruct socket: nil,
@@ -44,6 +47,9 @@ defmodule NervesTime.Ntpd do
               daemon: nil,
               synchronized?: false,
               clean_start?: true,
+              last_sync_report: nil,
+              sync_acquired_at: nil,
+              last_sync_at: nil,
               subscribers: %{}
   end
 
@@ -58,6 +64,14 @@ defmodule NervesTime.Ntpd do
   @spec synchronized?() :: boolean()
   def synchronized?() do
     GenServer.call(__MODULE__, :synchronized?)
+  end
+
+  @doc """
+  Return the current NTP synchronization status.
+  """
+  @spec sync_status() :: NervesTime.sync_status()
+  def sync_status() do
+    GenServer.call(__MODULE__, :sync_status)
   end
 
   @doc """
@@ -136,6 +150,17 @@ defmodule NervesTime.Ntpd do
   end
 
   @impl GenServer
+  def handle_call(:sync_status, _from, state) do
+    {:reply,
+     %{
+       synchronized?: state.synchronized?,
+       last_sync_report: state.last_sync_report,
+       sync_acquired_at: state.sync_acquired_at,
+       last_sync_at: state.last_sync_at
+     }, state}
+  end
+
+  @impl GenServer
   def handle_call(:clean_start?, _from, state) do
     {:reply, state.clean_start?, state}
   end
@@ -159,7 +184,20 @@ defmodule NervesTime.Ntpd do
 
   @impl GenServer
   def handle_call({:subscribe, pid}, _from, state) do
-    {:reply, :ok, subscribe_pid(state, pid)}
+    new_state = subscribe_pid(state, pid)
+
+    send(
+      pid,
+      {:nerves_time, :sync_status,
+       %{
+         synchronized?: new_state.synchronized?,
+         last_sync_report: new_state.last_sync_report,
+         sync_acquired_at: new_state.sync_acquired_at,
+         last_sync_at: new_state.last_sync_at
+       }}
+    )
+
+    {:reply, :ok, new_state}
   end
 
   @impl GenServer
@@ -278,8 +316,8 @@ defmodule NervesTime.Ntpd do
          {"stratum", _freq_drift_ppm, _offset, stratum, _poll_interval} = report,
          state
        ) do
-    notify_subscribers(state, :sync_aquired, report_payload(report))
-    {:noreply, %{state | synchronized?: maybe_update_rtc(stratum)}}
+    notify_subscribers(state, :sync_acquired, report_payload(report))
+    {:noreply, update_sync_state(state, report, stratum)}
   end
 
   defp handle_ntpd_report(
@@ -287,7 +325,7 @@ defmodule NervesTime.Ntpd do
          state
        ) do
     notify_subscribers(state, :sync_updated, report_payload(report))
-    {:noreply, %{state | synchronized?: maybe_update_rtc(stratum)}}
+    {:noreply, update_sync_state(state, report, stratum)}
   end
 
   defp handle_ntpd_report(
@@ -394,5 +432,25 @@ defmodule NervesTime.Ntpd do
       stratum: stratum,
       poll_interval: poll_interval
     }
+  end
+
+  defp update_sync_state(state, report, stratum) do
+    synchronized? = maybe_update_rtc(stratum)
+
+    case synchronized? do
+      true ->
+        now = DateTime.utc_now()
+
+        %{
+          state
+          | synchronized?: true,
+            last_sync_report: report_payload(report),
+            sync_acquired_at: state.sync_acquired_at || now,
+            last_sync_at: now
+        }
+
+      false ->
+        %{state | synchronized?: false}
+    end
   end
 end

--- a/lib/nerves_time/ntpd.ex
+++ b/lib/nerves_time/ntpd.ex
@@ -36,13 +36,15 @@ defmodule NervesTime.Ntpd do
             servers: [String.t()],
             daemon: nil | pid(),
             synchronized?: boolean(),
-            clean_start?: boolean()
+            clean_start?: boolean(),
+            subscribers: %{optional(pid()) => reference()}
           }
     defstruct socket: nil,
               servers: [],
               daemon: nil,
               synchronized?: false,
-              clean_start?: true
+              clean_start?: true,
+              subscribers: %{}
   end
 
   @spec start_link(any()) :: GenServer.on_start()
@@ -94,6 +96,22 @@ defmodule NervesTime.Ntpd do
     GenServer.call(__MODULE__, :restart_ntpd)
   end
 
+  @doc """
+  Subscribe a process to NTP daemon events.
+  """
+  @spec subscribe(pid()) :: :ok
+  def subscribe(pid \\ self()) when is_pid(pid) do
+    GenServer.call(__MODULE__, {:subscribe, pid})
+  end
+
+  @doc """
+  Unsubscribe a process from NTP daemon events.
+  """
+  @spec unsubscribe(pid()) :: :ok
+  def unsubscribe(pid \\ self()) when is_pid(pid) do
+    GenServer.call(__MODULE__, {:unsubscribe, pid})
+  end
+
   @impl GenServer
   def init(_args) do
     app_env = Application.get_all_env(:nerves_time)
@@ -140,6 +158,16 @@ defmodule NervesTime.Ntpd do
   end
 
   @impl GenServer
+  def handle_call({:subscribe, pid}, _from, state) do
+    {:reply, :ok, subscribe_pid(state, pid)}
+  end
+
+  @impl GenServer
+  def handle_call({:unsubscribe, pid}, _from, state) do
+    {:reply, :ok, unsubscribe_pid(state, pid)}
+  end
+
+  @impl GenServer
   def handle_info(:start_ntpd, %State{daemon: nil, servers: servers} = state)
       when servers != [] do
     new_state = start_ntpd(state)
@@ -168,6 +196,16 @@ defmodule NervesTime.Ntpd do
     # Log abnormal exits to aide debugging.
     Logger.info("[NervesTime] unexpected ntpd :EXIT #{inspect(from)}/#{inspect(reason)}")
     {:stop, reason, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, pid, _reason}, state) do
+    new_state =
+      case Map.fetch(state.subscribers, pid) do
+        {:ok, ^ref} -> %{state | subscribers: Map.delete(state.subscribers, pid)}
+        _ -> state
+      end
+
+    {:noreply, new_state}
   end
 
   defp prep_ntpd_start(%State{servers: []} = state) do
@@ -236,20 +274,36 @@ defmodule NervesTime.Ntpd do
     %{state | daemon: nil, socket: nil, synchronized?: false}
   end
 
-  defp handle_ntpd_report({"stratum", _freq_drift_ppm, _offset, stratum, _poll_interval}, state) do
+  defp handle_ntpd_report(
+         {"stratum", _freq_drift_ppm, _offset, stratum, _poll_interval} = report,
+         state
+       ) do
+    notify_subscribers(state, :sync_aquired, report_payload(report))
     {:noreply, %{state | synchronized?: maybe_update_rtc(stratum)}}
   end
 
-  defp handle_ntpd_report({"periodic", _freq_drift_ppm, _offset, stratum, _poll_interval}, state) do
+  defp handle_ntpd_report(
+         {"periodic", _freq_drift_ppm, _offset, stratum, _poll_interval} = report,
+         state
+       ) do
+    notify_subscribers(state, :sync_updated, report_payload(report))
     {:noreply, %{state | synchronized?: maybe_update_rtc(stratum)}}
   end
 
-  defp handle_ntpd_report({"step", _freq_drift_ppm, _offset, _stratum, _poll_interval}, state) do
+  defp handle_ntpd_report(
+         {"step", _freq_drift_ppm, _offset, _stratum, _poll_interval} = report,
+         state
+       ) do
+    notify_subscribers(state, :clock_step, report_payload(report))
     # Ignore
     {:noreply, state}
   end
 
-  defp handle_ntpd_report({"unsync", _freq_drift_ppm, _offset, _stratum, _poll_interval}, state) do
+  defp handle_ntpd_report(
+         {"unsync", _freq_drift_ppm, _offset, _stratum, _poll_interval} = report,
+         state
+       ) do
+    notify_subscribers(state, :sync_lost, report_payload(report))
     Logger.error("[NervesTime] ntpd reports that it is unsynchronized; restarting")
 
     # According to the Busybox ntpd docs, if you get an `unsync` notification, then
@@ -304,5 +358,41 @@ defmodule NervesTime.Ntpd do
 
   defp socket_path() do
     Path.join(System.tmp_dir!(), "nerves_time_comm")
+  end
+
+  defp subscribe_pid(%State{subscribers: subscribers} = state, pid) do
+    case Map.has_key?(subscribers, pid) do
+      true ->
+        state
+
+      false ->
+        %{state | subscribers: Map.put(subscribers, pid, Process.monitor(pid))}
+    end
+  end
+
+  defp unsubscribe_pid(%State{subscribers: subscribers} = state, pid) do
+    case Map.pop(subscribers, pid) do
+      {nil, _} ->
+        state
+
+      {ref, subscribers} ->
+        Process.demonitor(ref, [:flush])
+        %{state | subscribers: subscribers}
+    end
+  end
+
+  defp notify_subscribers(%State{subscribers: subscribers}, event, report) do
+    Enum.each(Map.keys(subscribers), fn pid ->
+      send(pid, {:nerves_time, event, report})
+    end)
+  end
+
+  defp report_payload({_report, freq_drift_ppm, offset, stratum, poll_interval}) do
+    %{
+      freq_drift_ppm: freq_drift_ppm,
+      offset: offset,
+      stratum: stratum,
+      poll_interval: poll_interval
+    }
   end
 end

--- a/test/nerves_time_test.exs
+++ b/test/nerves_time_test.exs
@@ -12,6 +12,28 @@ defmodule NervesTimeTest do
     Path.join(@fixtures, fixture)
   end
 
+  defp send_ntpd_report(report, env \\ []) do
+    ntpd_script_path = Application.app_dir(:nerves_time, ["priv", "ntpd_script"])
+    socket_path = Path.join(System.tmp_dir!(), "nerves_time_comm")
+
+    default_env = %{
+      "freq_drift_ppm" => "0",
+      "offset" => "0.0",
+      "stratum" => "16",
+      "poll_interval" => "1",
+      "SOCKET_PATH" => socket_path
+    }
+
+    merged_env =
+      env
+      |> Enum.into(%{}, fn {key, value} -> {to_string(key), value} end)
+      |> then(&Map.merge(default_env, &1))
+      |> Enum.to_list()
+
+    {_, 0} = System.cmd(ntpd_script_path, [report], env: merged_env)
+    :ok
+  end
+
   setup do
     capture_log(fn ->
       Application.stop(:nerves_time)
@@ -70,10 +92,16 @@ defmodule NervesTimeTest do
         Application.start(:nerves_time)
         Process.sleep(100)
 
-        refute NervesTime.Ntpd.clean_start?()
+        # Even if a healthy ntpd becomes available immediately, the delayed
+        # restart should prevent quick re-synchronization after a crash.
+        Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd"))
+        Process.sleep(500)
+
+        refute NervesTime.synchronized?()
       end)
 
     assert log =~ ~r/fake_busybox_ntpd_crash: Process exited with status 1/
+    assert log =~ "ntpd crash detected. Delaying next start..."
 
     # Restore env.
     Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd"))
@@ -198,5 +226,83 @@ defmodule NervesTimeTest do
     # Check for eventual synchronization
     Process.sleep(100)
     assert NervesTime.synchronized?()
+  end
+
+  test "subscribers receive NTP daemon events" do
+    Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd_net_down"))
+    Application.start(:nerves_time)
+    NervesTime.subscribe()
+
+    send_ntpd_report("stratum",
+      stratum: "3",
+      offset: "0.125",
+      poll_interval: "4",
+      freq_drift_ppm: "2"
+    )
+
+    assert_receive {:nerves_time, :sync_aquired,
+                    %{freq_drift_ppm: 2, offset: 0.125, stratum: 3, poll_interval: 4}},
+                   200
+
+    send_ntpd_report("periodic", stratum: "2", offset: "0.25")
+
+    assert_receive {:nerves_time, :sync_updated,
+                    %{freq_drift_ppm: 0, offset: 0.25, stratum: 2, poll_interval: 1}},
+                   200
+
+    send_ntpd_report("step", stratum: "2", offset: "1.5")
+
+    assert_receive {:nerves_time, :clock_step,
+                    %{freq_drift_ppm: 0, offset: 1.5, stratum: 2, poll_interval: 1}},
+                   200
+  end
+
+  test "subscribers receive sync_lost events" do
+    Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd_net_down"))
+    Application.start(:nerves_time)
+    NervesTime.subscribe()
+
+    log =
+      capture_log(fn ->
+        send_ntpd_report("unsync", stratum: "16")
+
+        assert_receive {:nerves_time, :sync_lost,
+                        %{freq_drift_ppm: 0, offset: offset, stratum: 16, poll_interval: 1}},
+                       200
+
+        assert offset in [0.0, -0.0]
+      end)
+
+    assert log =~ "ntpd reports that it is unsynchronized; restarting"
+  end
+
+  test "unsubscribe stops event delivery" do
+    Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd_net_down"))
+    Application.start(:nerves_time)
+    NervesTime.subscribe()
+    NervesTime.unsubscribe()
+
+    send_ntpd_report("step")
+
+    refute_receive {:nerves_time, :clock_step, _}, 200
+  end
+
+  test "subscriber processes are removed when they exit" do
+    Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd_net_down"))
+    Application.start(:nerves_time)
+
+    subscriber =
+      spawn(fn ->
+        NervesTime.subscribe()
+        Process.sleep(:infinity)
+      end)
+
+    Process.sleep(50)
+    assert Map.has_key?(:sys.get_state(NervesTime.Ntpd).subscribers, subscriber)
+
+    Process.exit(subscriber, :kill)
+    Process.sleep(50)
+
+    refute Map.has_key?(:sys.get_state(NervesTime.Ntpd).subscribers, subscriber)
   end
 end

--- a/test/nerves_time_test.exs
+++ b/test/nerves_time_test.exs
@@ -51,6 +51,13 @@ defmodule NervesTimeTest do
 
     # The fake_busybox_ntpd should have reported synchronization by this time.
     assert NervesTime.synchronized?()
+
+    assert %{
+             synchronized?: true,
+             last_sync_report: %{stratum: 3},
+             sync_acquired_at: %DateTime{},
+             last_sync_at: %DateTime{}
+           } = NervesTime.sync_status()
   end
 
   test "reports that time not synchronized when net is down" do
@@ -59,6 +66,14 @@ defmodule NervesTimeTest do
     Process.sleep(100)
 
     refute NervesTime.synchronized?()
+
+    assert %{
+             synchronized?: false,
+             last_sync_report: nil,
+             sync_acquired_at: nil,
+             last_sync_at: nil
+           } =
+             NervesTime.sync_status()
   end
 
   test "reports that time not synchronized when stratum 16" do
@@ -233,6 +248,15 @@ defmodule NervesTimeTest do
     Application.start(:nerves_time)
     NervesTime.subscribe()
 
+    assert_receive {:nerves_time, :sync_status,
+                    %{
+                      synchronized?: false,
+                      last_sync_report: nil,
+                      sync_acquired_at: nil,
+                      last_sync_at: nil
+                    }},
+                   200
+
     send_ntpd_report("stratum",
       stratum: "3",
       offset: "0.125",
@@ -240,15 +264,30 @@ defmodule NervesTimeTest do
       freq_drift_ppm: "2"
     )
 
-    assert_receive {:nerves_time, :sync_aquired,
+    assert_receive {:nerves_time, :sync_acquired,
                     %{freq_drift_ppm: 2, offset: 0.125, stratum: 3, poll_interval: 4}},
                    200
+
+    assert %{sync_acquired_at: sync_acquired_at, last_sync_at: first_last_sync_at} =
+             NervesTime.sync_status()
+
+    assert %DateTime{} = sync_acquired_at
+    assert %DateTime{} = first_last_sync_at
 
     send_ntpd_report("periodic", stratum: "2", offset: "0.25")
 
     assert_receive {:nerves_time, :sync_updated,
                     %{freq_drift_ppm: 0, offset: 0.25, stratum: 2, poll_interval: 1}},
                    200
+
+    assert %{
+             synchronized?: true,
+             last_sync_report: %{stratum: 2},
+             sync_acquired_at: ^sync_acquired_at,
+             last_sync_at: second_last_sync_at
+           } = NervesTime.sync_status()
+
+    assert DateTime.compare(second_last_sync_at, first_last_sync_at) in [:eq, :gt]
 
     send_ntpd_report("step", stratum: "2", offset: "1.5")
 
@@ -261,6 +300,15 @@ defmodule NervesTimeTest do
     Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd_net_down"))
     Application.start(:nerves_time)
     NervesTime.subscribe()
+
+    assert_receive {:nerves_time, :sync_status,
+                    %{
+                      synchronized?: false,
+                      last_sync_report: nil,
+                      sync_acquired_at: nil,
+                      last_sync_at: nil
+                    }},
+                   200
 
     log =
       capture_log(fn ->
@@ -276,15 +324,71 @@ defmodule NervesTimeTest do
     assert log =~ "ntpd reports that it is unsynchronized; restarting"
   end
 
+  test "sync status preserves last successful sync details after sync is lost" do
+    Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd"))
+    Application.start(:nerves_time)
+    Process.sleep(100)
+
+    assert %{
+             synchronized?: true,
+             last_sync_report: initial_report,
+             sync_acquired_at: sync_acquired_at,
+             last_sync_at: last_sync_at
+           } = NervesTime.sync_status()
+
+    assert %DateTime{} = sync_acquired_at
+    assert %DateTime{} = last_sync_at
+    assert %{stratum: 3} = initial_report
+
+    ntpd_script_path = Application.app_dir(:nerves_time, ["priv", "ntpd_script"])
+    socket_path = Path.join(System.tmp_dir!(), "nerves_time_comm")
+
+    capture_log(fn ->
+      System.cmd(ntpd_script_path, ["unsync"],
+        env: [
+          {"freq_drift_ppm", "0"},
+          {"offset", "0.0"},
+          {"stratum", "16"},
+          {"poll_interval", "1"},
+          {"SOCKET_PATH", socket_path}
+        ]
+      )
+    end)
+
+    assert %{
+             synchronized?: false,
+             last_sync_report: ^initial_report,
+             sync_acquired_at: ^sync_acquired_at,
+             last_sync_at: ^last_sync_at
+           } = NervesTime.sync_status()
+  end
+
   test "unsubscribe stops event delivery" do
     Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd_net_down"))
     Application.start(:nerves_time)
     NervesTime.subscribe()
+    assert_receive {:nerves_time, :sync_status, _}, 200
     NervesTime.unsubscribe()
 
     send_ntpd_report("step")
 
     refute_receive {:nerves_time, :clock_step, _}, 200
+  end
+
+  test "subscribe sends the current sync status snapshot" do
+    Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd"))
+    Application.start(:nerves_time)
+    Process.sleep(100)
+    NervesTime.subscribe()
+
+    assert_receive {:nerves_time, :sync_status,
+                    %{
+                      synchronized?: true,
+                      last_sync_report: %{stratum: 3},
+                      sync_acquired_at: %DateTime{},
+                      last_sync_at: %DateTime{}
+                    }},
+                   200
   end
 
   test "subscriber processes are removed when they exit" do


### PR DESCRIPTION
Adds a subscribe/unsubscribe event layer to `nerves_time` for NTP daemon reports.

I have a use case where devices do not have an RTC so I need to keep track of when clock gets syned/unsynced to respond and correct timestamped events. 

This adds a subscribe/unsubscribe event layer to `nerves_time` for NTP daemon reports and exposes current sync state for late subscribers.

New public API:
- `NervesTime.subscribe/0,1`
- `NervesTime.unsubscribe/0,1`
- `NervesTime.sync_status/0`

Subscribers receive messages in the form:

```elixir
{:nerves_time, event, payload}
```

Live events:
- `:sync_acquired`
- `:sync_updated`
- `:sync_lost`
- `:clock_step`

On subscribe, a snapshot is sent immediately:

```elixir
{:nerves_time, :sync_status,
 %{
   synchronized?: boolean(),
   last_sync_report: map() | nil,
   sync_acquired_at: DateTime.t() | nil,
   last_sync_at: DateTime.t() | nil
 }}
```

Notes on semantics:
- `sync_acquired_at` is when sync was first confirmed in the current runtime
- `last_sync_at` is the most recent successful sync update in the current runtime
- sync status is runtime-scoped and is not persisted across app/device restarts
- after `sync_lost`, the last successful sync metadata is preserved for context

Implementation details:
- tracks subscribers in `NervesTime.Ntpd`
- monitors subscriber processes and removes them automatically on exit
- sends an initial `:sync_status` snapshot on subscribe
- tracks current sync status and timestamps in `NervesTime.Ntpd`

Tests added/updated for:
- receiving `sync_acquired`, `sync_updated`, `sync_lost`, and `clock_step`
- initial `:sync_status` snapshot delivery
- `sync_status/0` behavior
- preserving last successful sync details after sync loss
- unsubscribe behavior
- automatic cleanup when a subscriber process exits