### PR TITLE
Add Credo.Check.Warning.UnsafeToAtom check

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -11,6 +11,7 @@
       checks: [
         {Credo.Check.Refactor.MapInto, false},
         {Credo.Check.Warning.LazyLogging, false},
+        {Credo.Check.Warning.UnsafeToAtom, []},
         {Credo.Check.Readability.LargeNumbers, only_greater_than: 86400},
         {Credo.Check.Readability.ParenthesesOnZeroArityDefs, parens: true},
         {Credo.Check.Readability.Specs, tags: []},


### PR DESCRIPTION
Enables the `Credo.Check.Warning.UnsafeToAtom` check to catch unsafe atom creation from uncontrolled input.