### PR TITLE
Add optional durable runtime NTP server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ config :nerves_time, :servers, [
 It's also possible to configure NTP servers at runtime. See
 `NervesTime.set_ntp_servers/1`.
 
+By default, servers set at runtime only live in memory and are lost on reboot.
+To persist them, configure a `:servers_file`. When set, `set_ntp_servers/1`
+writes the list to that file and it's reloaded on the next boot, taking
+precedence over `:servers`. An empty list is persisted as "NTP disabled" so
+that choice survives a reboot too.
+
+```elixir
+# config/config.exs
+
+config :nerves_time, :servers_file, "/data/nerves_time/ntp_servers"
+```
+
 ### Valid time range
 
 `nerves_time` has a concept of a valid time range. This minimizes time

--- a/lib/nerves_time.ex
+++ b/lib/nerves_time.ex
@@ -21,6 +21,13 @@ defmodule NervesTime do
 
   * `:servers` - a list of NTP servers for time synchronization. Specifying an
     empty list turns off NTP
+  * `:servers_file` - an optional file path for durably persisting the runtime
+    NTP server list. When set, `set_ntp_servers/1` writes to this file and the
+    list is reloaded on the next boot, taking precedence over `:servers`. This
+    is useful for devices that receive their NTP servers dynamically (e.g. from
+    provisioning or DHCP). An empty list is persisted as "NTP disabled" so that
+    choice also survives a reboot. When the file is absent, `NervesTime` falls
+    back to `:servers`.
   * `:time_file` - a file path for tracking the time. It allows the system to
     start with a reasonable time quickly on boot and before the Internet is
     available for NTP to work.
@@ -107,8 +114,19 @@ defmodule NervesTime do
   ```elixir
   config :nerves_time, :servers, []
   ```
+
+  To persist runtime changes across reboots, configure `:servers_file`. When
+  set, the list passed here is written to that file and reloaded on the next
+  boot, taking precedence over `:servers`:
+
+  ```elixir
+  config :nerves_time, :servers_file, "/data/nerves_time/ntp_servers"
+  ```
+
+  Returns `{:error, reason}` if persisting to `:servers_file` fails. The running
+  configuration is updated regardless.
   """
-  @spec set_ntp_servers([String.t()]) :: :ok
+  @spec set_ntp_servers([String.t()]) :: :ok | {:error, term()}
   defdelegate set_ntp_servers(servers), to: NervesTime.Ntpd
 
   @doc """

--- a/lib/nerves_time/ntpd.ex
+++ b/lib/nerves_time/ntpd.ex
@@ -22,12 +22,6 @@ defmodule NervesTime.Ntpd do
   @ntpd_clean_start_delay 10
 
   @default_ntpd_path "/usr/sbin/ntpd"
-  @default_ntp_servers [
-    "0.pool.ntp.org",
-    "1.pool.ntp.org",
-    "2.pool.ntp.org",
-    "3.pool.ntp.org"
-  ]
 
   defmodule State do
     @moduledoc false
@@ -88,8 +82,11 @@ defmodule NervesTime.Ntpd do
 
   @doc """
   Update the list of NTP servers to poll
+
+  When a `:servers_file` is configured, the list is also persisted so that it
+  survives a reboot. Returns `{:error, reason}` if persistence fails.
   """
-  @spec set_ntp_servers([String.t()]) :: :ok
+  @spec set_ntp_servers([String.t()]) :: :ok | {:error, term()}
   def set_ntp_servers(servers) when is_list(servers) do
     GenServer.call(__MODULE__, {:set_ntp_servers, servers})
   end
@@ -128,10 +125,7 @@ defmodule NervesTime.Ntpd do
 
   @impl GenServer
   def init(_args) do
-    app_env = Application.get_all_env(:nerves_time)
-    ntp_servers = Keyword.get(app_env, :servers, @default_ntp_servers)
-
-    {:ok, %State{servers: ntp_servers}, {:continue, :continue}}
+    {:ok, %State{servers: NervesTime.ServerConfig.get()}, {:continue, :continue}}
   end
 
   @impl GenServer
@@ -167,9 +161,12 @@ defmodule NervesTime.Ntpd do
 
   @impl GenServer
   def handle_call({:set_ntp_servers, servers}, _from, state) do
+    # Persist before restarting so that a write failure is surfaced to the
+    # caller. The running configuration is still updated either way.
+    reply = NervesTime.ServerConfig.put(servers)
     new_state = %{state | servers: servers} |> cleanup_and_restart()
 
-    {:reply, :ok, new_state}
+    {:reply, reply, new_state}
   end
 
   @impl GenServer

--- a/lib/nerves_time/server_config.ex
+++ b/lib/nerves_time/server_config.ex
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2026 Eliel A. Gordon
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesTime.ServerConfig do
+  @moduledoc false
+  # Resolves and persists the NTP server list across its possible sources.
+  #
+  # In precedence order, the servers come from:
+  #
+  #   1. the durable runtime file named by the `:servers_file` application key,
+  #      when configured and present
+  #   2. the static `:servers` application key
+  #   3. the built-in NTP Pool defaults
+  #
+  # When `:servers_file` is configured, the list set via
+  # `NervesTime.set_ntp_servers/1` is written there so the choice survives a
+  # reboot. The presence of the file is the signal to use the persisted list:
+  # an empty list is stored as an explicit "NTP disabled" marker so that turning
+  # NTP off also survives a reboot. When `:servers_file` is not configured,
+  # persistence is a no-op and only the static config is consulted.
+  require Logger
+
+  @default_ntp_servers [
+    "0.pool.ntp.org",
+    "1.pool.ntp.org",
+    "2.pool.ntp.org",
+    "3.pool.ntp.org"
+  ]
+
+  @doc """
+  Return the NTP servers to use.
+
+  Prefers the persisted `:servers_file` when configured and present, otherwise
+  falls back to the `:servers` application key (defaulting to the NTP Pool). A
+  persisted empty list is honored as "NTP disabled".
+  """
+  @spec get() :: [String.t()]
+  def get() do
+    case load_file() do
+      {:ok, servers} -> servers
+      :not_present -> Application.get_env(:nerves_time, :servers, @default_ntp_servers)
+    end
+  end
+
+  @doc """
+  Persist a normalized NTP server list.
+
+  Returns `:ok` on success or when no servers file is configured (a no-op).
+  Returns `{:error, reason}` and logs the failure when the file can't be
+  written.
+  """
+  @spec put([String.t()]) :: :ok | {:error, term()}
+  def put(servers) when is_list(servers) do
+    case file_path() do
+      nil -> :ok
+      file -> write_file(file, servers)
+    end
+  end
+
+  defp file_path() do
+    Application.get_env(:nerves_time, :servers_file)
+  end
+
+  # Returns `{:ok, servers}` when the file exists (servers may be `[]`), or
+  # `:not_present` when no file is configured, it doesn't exist yet, or it
+  # couldn't be read (in which case the failure is logged).
+  defp load_file() do
+    case file_path() do
+      nil ->
+        :not_present
+
+      file ->
+        case File.read(file) do
+          {:ok, contents} ->
+            {:ok, parse(contents)}
+
+          {:error, :enoent} ->
+            :not_present
+
+          {:error, reason} ->
+            Logger.warning(
+              "[NervesTime] Failed to read servers file #{inspect(file)}: #{inspect(reason)}"
+            )
+
+            :not_present
+        end
+    end
+  end
+
+  defp parse(contents) do
+    contents
+    |> String.split("\n")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == "" or String.starts_with?(&1, "#")))
+  end
+
+  defp write_file(file, servers) do
+    with :ok <- file |> Path.dirname() |> File.mkdir_p(),
+         :ok <- File.write(file, format(servers)) do
+      :ok
+    else
+      {:error, reason} = error ->
+        Logger.warning(
+          "[NervesTime] Failed to persist servers file #{inspect(file)}: #{inspect(reason)}"
+        )
+
+        error
+    end
+  end
+
+  # An empty list still writes a file so that the "NTP disabled" choice is
+  # distinguishable from "no file persisted yet" on the next boot.
+  defp format([]), do: "# NTP disabled\n"
+  defp format(servers), do: Enum.map_join(servers, "\n", & &1) <> "\n"
+end

--- a/test/nerves_time_test.exs
+++ b/test/nerves_time_test.exs
@@ -12,6 +12,16 @@ defmodule NervesTimeTest do
     Path.join(@fixtures, fixture)
   end
 
+  defp servers_file_path() do
+    Path.join([System.tmp_dir!(), "nerves_time_test_servers", "ntp_servers"])
+  end
+
+  defp cleanup_servers_file() do
+    Application.delete_env(:nerves_time, :servers_file)
+    Application.delete_env(:nerves_time, :servers)
+    File.rm_rf!(Path.dirname(servers_file_path()))
+  end
+
   defp send_ntpd_report(report, env \\ []) do
     ntpd_script_path = Application.app_dir(:nerves_time, ["priv", "ntpd_script"])
     socket_path = Path.join(System.tmp_dir!(), "nerves_time_comm")
@@ -40,6 +50,10 @@ defmodule NervesTimeTest do
       socket_path = Path.join(System.tmp_dir!(), "nerves_time_comm")
       File.rm(socket_path)
     end)
+
+    # Ensure a leaked servers_file config from a prior test doesn't bleed into
+    # the next one.
+    Application.delete_env(:nerves_time, :servers_file)
 
     :ok
   end
@@ -188,6 +202,81 @@ defmodule NervesTimeTest do
 
     # Use the defaults for servers for the other tests.
     Application.delete_env(:nerves_time, :servers)
+  end
+
+  test "loads persisted servers file at startup, taking precedence over :servers" do
+    file = servers_file_path()
+    File.mkdir_p!(Path.dirname(file))
+    File.write!(file, "1.2.3.4\n")
+
+    Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd"))
+    Application.put_env(:nerves_time, :servers, ["should.be.ignored"])
+    Application.put_env(:nerves_time, :servers_file, file)
+    Application.start(:nerves_time)
+    Process.sleep(100)
+
+    assert NervesTime.ntp_servers() == ["1.2.3.4"]
+
+    cleanup_servers_file()
+  end
+
+  test "falls back to :servers when no persisted file exists" do
+    file = servers_file_path()
+
+    Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd"))
+    Application.put_env(:nerves_time, :servers, ["fallback.example.com"])
+    Application.put_env(:nerves_time, :servers_file, file)
+    Application.start(:nerves_time)
+    Process.sleep(100)
+
+    assert NervesTime.ntp_servers() == ["fallback.example.com"]
+
+    cleanup_servers_file()
+  end
+
+  test "set_ntp_servers persists to the servers file and survives a restart" do
+    file = servers_file_path()
+
+    Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd"))
+    Application.put_env(:nerves_time, :servers, [])
+    Application.put_env(:nerves_time, :servers_file, file)
+    Application.start(:nerves_time)
+    Process.sleep(100)
+
+    assert :ok = NervesTime.set_ntp_servers(["1.2.3.4"])
+    assert File.read!(file) =~ "1.2.3.4"
+
+    # Restart the application and confirm the persisted list is reloaded.
+    capture_log(fn -> Application.stop(:nerves_time) end)
+    Application.start(:nerves_time)
+    Process.sleep(100)
+
+    assert NervesTime.ntp_servers() == ["1.2.3.4"]
+
+    cleanup_servers_file()
+  end
+
+  test "persisting an empty list disables NTP across a restart" do
+    file = servers_file_path()
+
+    Application.put_env(:nerves_time, :ntpd, fixture_path("fake_busybox_ntpd"))
+    Application.put_env(:nerves_time, :servers, ["0.pool.ntp.org"])
+    Application.put_env(:nerves_time, :servers_file, file)
+    Application.start(:nerves_time)
+    Process.sleep(100)
+
+    assert :ok = NervesTime.set_ntp_servers([])
+    assert File.exists?(file)
+
+    # On restart the present-but-empty file beats the non-empty :servers config.
+    capture_log(fn -> Application.stop(:nerves_time) end)
+    Application.start(:nerves_time)
+    Process.sleep(100)
+
+    assert NervesTime.ntp_servers() == []
+    refute NervesTime.synchronized?()
+
+    cleanup_servers_file()
   end
 
   test "resynchronizes after unsync report" do

--- a/test/server_config_test.exs
+++ b/test/server_config_test.exs
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: 2026 Eliel A. Gordon
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule NervesTime.ServerConfigTest do
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
+
+  alias NervesTime.ServerConfig
+
+  setup do
+    dir = Path.join(System.tmp_dir!(), "nerves_time_server_config_test")
+    File.rm_rf!(dir)
+    path = Path.join(dir, "ntp_servers")
+
+    on_exit(fn ->
+      Application.delete_env(:nerves_time, :servers_file)
+      Application.delete_env(:nerves_time, :servers)
+      File.rm_rf!(dir)
+    end)
+
+    {:ok, dir: dir, path: path}
+  end
+
+  describe "get/0" do
+    test "falls back to the :servers config when no servers file is configured" do
+      Application.delete_env(:nerves_time, :servers_file)
+      Application.put_env(:nerves_time, :servers, ["config.example.com"])
+
+      assert ServerConfig.get() == ["config.example.com"]
+    end
+
+    test "falls back to the NTP Pool defaults when nothing is configured" do
+      Application.delete_env(:nerves_time, :servers_file)
+      Application.delete_env(:nerves_time, :servers)
+
+      assert ServerConfig.get() == [
+               "0.pool.ntp.org",
+               "1.pool.ntp.org",
+               "2.pool.ntp.org",
+               "3.pool.ntp.org"
+             ]
+    end
+
+    test "falls back to :servers when the file is configured but absent", %{path: path} do
+      Application.put_env(:nerves_time, :servers_file, path)
+      Application.put_env(:nerves_time, :servers, ["config.example.com"])
+
+      assert ServerConfig.get() == ["config.example.com"]
+    end
+
+    test "prefers the persisted file over :servers when present", %{path: path} do
+      Application.put_env(:nerves_time, :servers_file, path)
+      Application.put_env(:nerves_time, :servers, ["should.be.ignored"])
+      File.mkdir_p!(Path.dirname(path))
+      File.write!(path, "1.2.3.4\n")
+
+      assert ServerConfig.get() == ["1.2.3.4"]
+    end
+
+    test "a present-but-empty file is honored as NTP disabled", %{path: path} do
+      Application.put_env(:nerves_time, :servers_file, path)
+      Application.put_env(:nerves_time, :servers, ["should.be.ignored"])
+      File.mkdir_p!(Path.dirname(path))
+      File.write!(path, "# NTP disabled\n")
+
+      assert ServerConfig.get() == []
+    end
+
+    test "ignores blank lines and comments when parsing", %{path: path} do
+      Application.put_env(:nerves_time, :servers_file, path)
+      File.mkdir_p!(Path.dirname(path))
+      File.write!(path, "# a comment\n\n  1.2.3.4  \n\n2.3.4.5\n")
+
+      assert ServerConfig.get() == ["1.2.3.4", "2.3.4.5"]
+    end
+  end
+
+  describe "put/1" do
+    test "round-trips a server list through get/0", %{path: path} do
+      Application.put_env(:nerves_time, :servers_file, path)
+
+      assert :ok = ServerConfig.put(["1.2.3.4", "time.example.com"])
+      assert ServerConfig.get() == ["1.2.3.4", "time.example.com"]
+    end
+
+    test "creates intermediate directories when saving", %{dir: dir} do
+      path = Path.join([dir, "nested", "deeper", "ntp_servers"])
+      Application.put_env(:nerves_time, :servers_file, path)
+
+      assert :ok = ServerConfig.put(["1.2.3.4"])
+      assert File.exists?(path)
+    end
+
+    test "persists an empty list so it survives a reboot", %{path: path} do
+      Application.put_env(:nerves_time, :servers_file, path)
+
+      assert :ok = ServerConfig.put([])
+      # The file is present (so it takes precedence over :servers) but yields [].
+      assert File.exists?(path)
+      assert ServerConfig.get() == []
+    end
+
+    test "is a no-op returning :ok when not configured" do
+      Application.delete_env(:nerves_time, :servers_file)
+      assert :ok = ServerConfig.put(["1.2.3.4"])
+    end
+
+    test "returns and logs an error when the file can't be written", %{dir: dir} do
+      # Point at a path whose parent is a regular file so mkdir_p fails.
+      blocker = Path.join(dir, "blocker")
+      File.mkdir_p!(dir)
+      File.write!(blocker, "")
+      path = Path.join(blocker, "ntp_servers")
+      Application.put_env(:nerves_time, :servers_file, path)
+
+      log =
+        capture_log(fn ->
+          assert {:error, _reason} = ServerConfig.put(["1.2.3.4"])
+        end)
+
+      assert log =~ "Failed to persist servers file"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds an optional `:servers_file` config key for durably persisting the runtime NTP server list.

Today, `NervesTime.set_ntp_servers/1` updates the running `ntpd` configuration, but the new server list only lives in GenServer state. After a reboot, `NervesTime` falls back to `config :nerves_time, :servers`. This makes it hard to support devices that receive their NTP servers dynamically (provisioning, legacy network migration, DHCP/ConnMan metadata, or user configuration).

When `:servers_file` is configured, the list set at runtime is written to that file and reloaded on the next boot, taking precedence over `:servers`:

```elixir
config :nerves_time,
  servers: [],
  servers_file: "/data/nerves_time/ntp_servers"
```

## Behavior

- On startup, load `:servers_file` when configured and present.
- Fall back to `:servers` when no persisted file exists.
- `set_ntp_servers/1` persists the server list when `:servers_file` is configured.
- An empty list is persisted as an explicit "NTP disabled" marker so that choice survives a reboot. The *presence* of the file is the signal to use the persisted list, so a present-but-empty file yields `[]` (NTP off) rather than falling back to `:servers`.
- Persistence failures are both returned (`set_ntp_servers/1` now returns `:ok | {:error, term()}`) and logged. The running configuration is updated regardless.

**Behavior is unchanged unless `:servers_file` is configured.**

## Implementation

- New `NervesTime.ServerFile` module encapsulates load/save. File format is one server per line; blank lines and `#` comments are ignored. Intermediate directories are created on save.
- `NervesTime.Ntpd.init/1` loads from `ServerFile` first, falling back to `:servers` (then the built-in pool default).
- `set_ntp_servers/1` persists before restarting `ntpd` and returns the persistence result.

## Tests

- `test/server_file_test.exs` — unit tests for load/save round-trip, directory creation, empty-list ("NTP disabled") semantics, comment/blank-line parsing, no-op when unconfigured, and write-failure error + log.
- `test/nerves_time_test.exs` — integration tests for startup precedence, fallback to `:servers`, persist-and-reload across an application restart, and disable-via-empty-list across a restart.

All tests pass; `mix format`, `mix credo --strict`, and `mix dialyzer` are clean.
