### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # nerves_time
 
 [![Hex version](https://img.shields.io/hexpm/v/nerves_time.svg "Hex version")](https://hex.pm/packages/nerves_time)
-[![API docs](https://img.shields.io/hexpm/v/nerves_time.svg?label=hexdocs "API docs")](https://hexdocs.pm/nerves_time/NervesTime.html)
+[![API docs](https://img.shields.io/hexpm/v/nerves_time.svg?label=hexdocs "API docs")](https://nerves-time.hexdocs.pm/NervesTime.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/nerves-time/nerves_time/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/nerves-time/nerves_time/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/nerves-time/nerves_time)](https://api.reuse.software/info/github.com/nerves-time/nerves_time)
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves-time.hexdocs.pm/NervesTime.html): Status 404
⚠️ Verification finished: 0 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>