### PR TITLE
Update Elixir 1.17 CI image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ tags: &tags
     1.20.0-erlang-29.0.1-alpine-3.23.4,
     1.19.5-erlang-28.5-alpine-3.23.4,
     1.18.4-erlang-28.5-alpine-3.23.4,
-    1.17.3-erlang-27.3.4.11-alpine-3.23.4,
+    1.17.3-erlang-27.3.4.16-alpine-3.24.1,
     1.16.3-erlang-26.2.5-alpine-3.20.0,
     1.15.7-erlang-26.2.1-alpine-3.18.4,
     1.14.5-erlang-25.3.2-alpine-3.18.0,


### PR DESCRIPTION
Update the Elixir 1.17 CircleCI image to OTP 27.3.4.16 and Alpine 3.24.1. This avoids an OTP 27 bug that is causing CI failures.